### PR TITLE
Update CI and CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,19 @@ jobs:
           ghc-version: '9.4.7'
           cabal-version: '3.8.1.0'
 
+      - name: Create directory for executable
+        working-directory: ./translators
+        run: mkdir -p ./code/executable
+
       - name: Build the translator executable
         working-directory: ./translators
-        run: cabal build
+        run: cabal install --installdir=./code/executable --install-method=copy
 
       - name: Store translator as an artifact
         uses: actions/upload-artifact@v4
         with:
           name: translator-folder
-          path: ./translators/dist-newstyle/build/x86_64-linux/ghc-9.4.7/translators-0.1.0.0/x/translators/build/translators/translators
+          path: ./translators/code/executable/translators
           retention-days: 2
   build_cli:
     runs-on: ubuntu-latest
@@ -66,9 +70,6 @@ jobs:
         with:
           name: translator-folder
           path: ./translator-folder
-      - 
-        name: Check files
-        run: ls -l
       -
         name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/cli/cmd/generate-list.go
+++ b/cli/cmd/generate-list.go
@@ -44,6 +44,7 @@ var generateListCmd = &cobra.Command{
 		}
 
 		slices.Sort(datapoints)
+		data.Testcases[0].LowerBound = datapoints[0]
 		for i := 0; i < len(datapoints); i++ {
 			log.Printf("datapoint %d out of %d\n", i+1, len(datapoints))
 			translateTest(testcase, datapoints[i])
@@ -122,6 +123,8 @@ func dataTemplate(test Testcase) Overview {
 			{
 				Name:        test.file_name,
 				Description: test.desc,
+				Interval:    "None",
+				LowerBound:  1,
 				Languages: []LanguageJSON{
 					{
 						Name:        "Coq",
@@ -235,7 +238,7 @@ func run_test(test Testcase, dataMap map[string][]Data, exit_status map[string]s
 		}()
 
 		select {
-		case <-time.After(30 * time.Second):
+		case <-time.After(120 * time.Second):
 			syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 			log.Println("Process killed, context deadline exceeded")
 			exit_status[Language_list[i].name] = "time"
@@ -259,6 +262,7 @@ func run_test(test Testcase, dataMap map[string][]Data, exit_status map[string]s
 			if err != nil {
 				log.Println("Could not unmarshal test data", err)
 			} else {
+				test_data.Memory = test_data.Memory / 1000
 				if interval == "log" {
 					test_data.Memory = safe_log(test_data.Memory)
 					test_data.Real_time = safe_log(test_data.Real_time)

--- a/cli/cmd/generate-range.go
+++ b/cli/cmd/generate-range.go
@@ -53,6 +53,8 @@ var generateRangeCmd = &cobra.Command{
 		if interval == "quadratic" {
 			i = int(math.Pow(math.Ceil(math.Sqrt(float64(i))), 2))
 		}
+		data.Testcases[0].LowerBound = i
+		data.Testcases[0].Interval = interval
 
 		for i <= upperBound {
 			if point > num_points {

--- a/cli/cmd/info.go
+++ b/cli/cmd/info.go
@@ -22,6 +22,8 @@ type Language struct {
 type Test struct {
 	Name        string         `json:"name"`
 	Description string         `json:"description"`
+	Interval    string         `json:"interval"`
+	LowerBound  int            `json:"lower_bound"`
 	Languages   []LanguageJSON `json:"languages"`
 }
 
@@ -183,7 +185,7 @@ var Language_list = []Language{
 	{
 		"Agda",
 		".agda",
-		"agda",
+		"agda +RTS -M2.8G -RTS",
 	},
 	{
 		"Idris",

--- a/vercel.py
+++ b/vercel.py
@@ -31,7 +31,7 @@ def delete_old_previews(token):
            date_time = datetime.datetime.fromtimestamp(time_in_s)
            current_time = datetime.datetime.now()
            time_difference = current_time - date_time
-           if time_difference > datetime.timedelta(hours=6):
+           if time_difference > datetime.timedelta(hours=24):
                 old_previews += [deployment["uid"]]
            else:
                 newer_previews[deployment["uid"]] = time_difference
@@ -46,7 +46,7 @@ def delete_old_previews(token):
     active_previews = preview_count - deleted_preview
 
     # if there are still more than 10 active preview deployments and delete the oldest ones until there are only 9 active deployments
-    while active_previews >= 10:
+    while active_previews >= 15:
         time_differences = list(newer_previews.values())
         oldest_creation = max(time_difference)
         deployment_id = list(newer_previews.keys())[time_differences.index(oldest_creation)]


### PR DESCRIPTION
- using cabal install to build and store translator executable
- Small changes to cabal file
- changing memory from KB to MB
- resource cap on heap for agda (2.8GB)
- 2 minute timeout on type checking commands
- lowerbound + interval added to JSON file
- Remove Vercel preview deployments older than 24h and limit to 15