### PR TITLE
Fix capitalization, generalize datatype param types

### DIFF
--- a/translators/Grammar.hs
+++ b/translators/Grammar.hs
@@ -13,8 +13,8 @@ data Definition = DefFun Name (Maybe Type) [Arg] Expr
                 | DefNesFun Name (Maybe Type) [Arg] Expr -- Constructor for nested functions
                 | DefPatt Name [(Name,Type)] Type Name [([Arg], Expr)] --function name; name,type is parameters for roq; output type; name is input to match with for coq, constructors
                 | DefVar Name (Maybe Type) Expr
-                | DefDataType Name [(Name,Type)] Type -- usually type is Set
-                | DefPDataType Name [Name] [(Name,Type)] Type
+                | DefDataType Name [(Name,Type)] Type -- datatype name, constructors, usually type is Set
+                | DefPDataType Name [(Name, Type)] [(Name,Type)] Type --datatype name, parameters, constrcutors, overall type
                 | DefRecType Name (Maybe [Arg]) (Maybe Name) [(Name,Type)] Type -- (Maybe Arg) for parameters, (Maybe Name) is the type constructor
                 | InitRec Name Name (Maybe Name)[(String, Expr)] -- record name, record type, possible constructor type (this auto fills in, only needed for Chain dependent constructor test)
                 | OpenName Name --just for Lean, to refer to user-defined datatypes directly
@@ -49,6 +49,8 @@ data Expr = Var Name
         | ListEmpty             -- Represents `[]`
         | ListCons Expr Expr      -- Represents list construction, e.g. `1 :: []`
         | Paren Expr
+        | Constructor Name
+        
         
 -- aliases for readability purposes
 type Name = String

--- a/translators/PrintAgda.hs
+++ b/translators/PrintAgda.hs
@@ -18,6 +18,7 @@ printType (DCon name types exprs) = -- For dependent type constructors (like suc
 printType (Suc t) = "(suc " ++ printType t ++ ")"
 printType (Index names ty) = "{" ++ unwords names ++ " : " ++ printType ty ++ "}"
 -- Print expressions
+printExpr (Constructor name) = name
 printExpr (Var var) = var
 printExpr (Int int) = show int
 printExpr (Bool bool) = show bool
@@ -62,7 +63,7 @@ printDef (DefPatt var params ty _ cons) =
     var ++ ": " ++ (printType (foldr (\x y -> Arr x y) ty (map snd params))) ++ unwords (map (\(a,e) -> "\n\t" ++ var ++ " " ++ (unwords $ map (\(Arg name _) -> name) a) ++ " = " ++ printExpr e) cons)
 -- Function to print datatype definitions
 printDef (DefDataType name cons ty) = "data " ++ name ++ " : " ++ printType ty ++ " where" ++ unwords (map (\(name, t) -> "\n " ++ name ++ " : " ++ printType t) cons) ++ "\n"
-printDef (DefPDataType name params cons ty) = "data " ++ name ++ " " ++ unwords (map (\x -> "(" ++ x ++ " : Set) ") params) ++ " : Set where" ++ unwords (map (\(name, t) -> "\n " ++ name ++ " : " ++ printType t) cons) ++ "\n"
+printDef (DefPDataType name params cons ty) = "data " ++ name ++ " " ++ unwords (map (\(x, y) -> "(" ++ x ++ " : " ++ printType y ++ ") ") params) ++ " : " ++ printType ty ++ " where" ++ unwords (map (\(name, t) -> "\n " ++ name ++ " : " ++ printType t) cons) ++ "\n"
 --printDef (DefPDataType name params cons ty) = "data " ++ name ++ " : " ++ foldr (\x y -> "(" ++ x ++ " : Set) -> " ++ y) datatype params ++ " where" ++ unwords (map (\(name, t) -> "\n " ++ name ++ " : " ++ unwords (map (\p -> p ++ " ->") params) ++ printType t) cons) ++ "\n"
 
 

--- a/translators/PrintIdris.hs
+++ b/translators/PrintIdris.hs
@@ -18,6 +18,7 @@ printType (Index names ty) = "{" ++ unwords' names ++ " : " ++ printType ty ++ "
     unwords' [] = ""
     unwords' [n] = n
     unwords' names = foldl1 (\ x n -> x ++ ", " ++ n) names
+printExpr (Constructor name) = name
 printExpr (Var var) = var
 printExpr (Int int) = show int
 printExpr (Bool bool) = show bool
@@ -58,7 +59,7 @@ printDef (DefNesFun var (Just t) args expr) = printDef (DefFun var (Just t) args
 printDef (DefPatt var params ty _ cons) =
     var ++ " : " ++ printType (foldr (\x y -> Arr x y) ty (map snd params)) ++ unwords (map (\(a,e) -> "\n\t" ++ var ++ " " ++ (unwords $ map (\(Arg name _) -> name) a) ++ " = " ++ printExpr e ) cons)
 printDef (DefDataType name cons ty) = "data " ++ name ++ " : " ++ printType ty ++ " where" ++ unwords (map (\(name, t) -> "\n " ++ name ++ " : " ++ printType t) cons) ++ "\n"
-printDef (DefPDataType name params cons ty) = "data " ++ name ++ " : " ++ foldr (\x y -> "(" ++ x ++ " : Type) -> " ++ y) datatype params ++ " where" ++ unwords (map (\(name, t) -> "\n " ++ name ++ " : " ++ unwords (map (\p -> p ++ " ->") params) ++ printType t) cons) ++ "\n"
+printDef (DefPDataType name params cons ty) = "data " ++ name ++ " : " ++ foldr (\(x, y) z -> "(" ++ x ++ " : " ++ printType y ++ ") -> " ++ z) datatype params ++ " where" ++ unwords (map (\(name, t) -> "\n " ++ name ++ " : " ++ unwords (map (\(p, _) -> p ++ " ->") params) ++ printType t) cons) ++ "\n"
 
 -- Record Defn
 printDef (DefRecType name maybeParams maybeConName fields _) =

--- a/translators/PrintLean.hs
+++ b/translators/PrintLean.hs
@@ -20,6 +20,7 @@ printReturnType (Arr _ t) = printReturnType t
 printArg a = "(" ++ (arg a) ++ " : " ++ (printType $ ty a) ++ ")"
 
 -- Print expressions (unchanged)
+printExpr (Constructor name) = name
 printExpr (Var var) = var
 printExpr (Int int) = show int
 printExpr (Bool bool) = show bool
@@ -56,7 +57,7 @@ printDef _ (DefPatt var params ty _ cons) =
     var ++ " : " ++ printType (foldr (\x y -> Arr x y) ty (map snd params)) ++ unwords (map (\(a,e) -> "\n| " ++ (unwords $ map (\(Arg name _) -> name) a) ++ " => " ++ printExpr e ) cons)
 printDef _ (DefDataType str args t) = "inductive " ++ str ++ " : " ++ printType t ++ " where " ++ unwords (map (\(x, y) -> "\n| " ++ x ++ " : " ++ printType y) args)
 printDef _ (DefPDataType str params args t) =
-   "inductive " ++ str ++ unwords (map (\x -> " (" ++ x ++ ": Type)") params) ++ " where " ++ unwords (map (\(x, y) -> "\n| " ++ x ++ " : " ++ (printType y)) args)
+   "inductive " ++ str ++ unwords (map (\(x, y) -> " (" ++ x ++ ": " ++ printType y ++ ")") params) ++ " where " ++ unwords (map (\(x, y) -> "\n| " ++ x ++ " : " ++ (printType y)) args)
 
 -- records Def
 printDef _ (DefRecType name params maybeConName fields _) =

--- a/translators/PrintRocq.hs
+++ b/translators/PrintRocq.hs
@@ -3,7 +3,7 @@ module PrintRocq (runRocq) where
 import Grammar
     ( Arg(arg, ty, Arg),
       Definition(DefNesFun, DefVar, DefFun, DefRecType, InitRec, DefDataType, DefPDataType, DefPatt, OpenName),
-      Expr(FunCall, Var, Int, Bool, String, Mon, Bin, Let, If, Where, VecEmpty, VecCons, Paren, ListEmpty, ListCons),
+      Expr(Constructor, FunCall, Var, Int, Bool, String, Mon, Bin, Let, If, Where, VecEmpty, VecCons, Paren, ListEmpty, ListCons),
       Module(File, Module),
       Type(Arr, Con, TVar, PCon, DCon, Suc, Index) )
 import Data.Char
@@ -26,6 +26,7 @@ printType (Index names ty) = "forall {" ++ unwords names ++ " : " ++ printType t
 printReturnType (Con t) = map toLower t --required for nested functions
 printReturnType (Arr _ t) = printReturnType t
 printArg a = "(" ++ (arg a) ++ " : " ++ (printType $ ty a) ++ ")"
+printExpr (Constructor name) = map toLower name
 printExpr (Var var) = var
 printExpr (Int int) = show int
 printExpr (Bool bool) = show bool
@@ -59,9 +60,9 @@ printDef (DefFun var (Just t) args expr) = "Definition " ++ var ++ (foldl (\x y 
 printDef (DefNesFun var Nothing args expr) = var ++ " " ++ (unwords $ map arg args) ++ " := " ++ printExpr expr
 printDef (DefNesFun var (Just t) args expr) = var ++ " " ++ (unwords $ map printArg args) ++ " : " ++ printReturnType t ++ " := " ++ printExpr expr
 
-printDef (DefPatt var params ty m cons) = var ++ " " ++ (unwords $ map (\(x, y) -> " (" ++ x ++ " : " ++ printType y ++ ")") params) ++ " : " ++ printType ty ++ " := \nmatch " ++ m ++ " with" ++ unwords (map (\(a, e) -> "\n| " ++ (unwords $ map (\(Arg name _) -> name) a) ++ " => " ++ printExpr e) cons) ++ " end"
+printDef (DefPatt var params ty m cons) = var ++ " " ++ (unwords $ map (\(x, y) -> " (" ++ x ++ " : " ++ printType y ++ ")") params) ++ " : " ++ printType ty ++ " := \nmatch " ++ m ++ " with" ++ unwords (map (\(a, e) -> "\n| " ++ (unwords $ map (\(Arg name _) -> map toLower name) a) ++ " => " ++ printExpr e) cons) ++ " end"
 printDef (DefDataType name args ty) = "Inductive " ++ map toLower name ++ " : " ++ printType ty ++ " := " ++ unwords (map (\(x, y) -> "\n| " ++ map toLower x ++ " : " ++ (printType y)) args) ++ "."
-printDef (DefPDataType name params args ty) = "Inductive " ++ map toLower name ++ unwords (map (\x -> " (" ++ map toLower x ++ ": Type)") params) ++ " : " ++ printType ty ++ " := " ++ unwords (map (\(x, y) -> "\n| " ++ map toLower x ++ " : " ++ (printType y)) args) ++ "."
+printDef (DefPDataType name params args ty) = "Inductive " ++ map toLower name ++ unwords (map (\(x, y) -> " (" ++ map toLower x ++ ": " ++ printType y ++ ")") params) ++ " : " ++ printType ty ++ " := " ++ unwords (map (\(x, y) -> "\n| " ++ map toLower x ++ " : " ++ (printType y)) args) ++ "."
 
 --Function for Records
 printDef (DefRecType name params maybeConName fields _) =

--- a/translators/Tests.hs
+++ b/translators/Tests.hs
@@ -158,7 +158,7 @@ _tests =
         [DefDataType "D" (map (\ i -> ("C" ++ show i, Con "D")) [1 .. n]) (Con "Type")]
     , \n ->  --13
         Module "Parameters_Datatypes"
-        [DefPDataType "D" (map (\i -> ("p" ++ show i)) [1 .. n]) [("C", PCon "D" (map (\i -> Con ("p" ++ show i) ) [1 .. n]))] (Con "Type")]
+        [DefPDataType "D" (map (\i -> ("p" ++ show i, Con "Type")) [1 .. n]) [("C", PCon "D" (map (\i -> Con ("p" ++ show i) ) [1 .. n]))] (Con "Type")]
     
     , --14 Description: defines N variables, and uses both the first and last one in a declaration, N>=2
      \n ->
@@ -213,7 +213,7 @@ _tests =
     in File "SingleLongLine" singleLine
     , \n ->  --18 Description: A single datatype where 'n' represents the number of 'Type' parameters, all needed for 'n' constructors
         Module "ConstructorsParameters_Datatypes"
-        [DefPDataType "D" (map (\i -> ("p" ++ show i)) [1 .. n]) (map (\ i -> ("C" ++ show i,  PCon "D" (map (\j -> Con ("p" ++ show j) ) [1 .. n]))) [1 .. n]) (Con "Type")]
+        [DefPDataType "D" (map (\i -> ("p" ++ show i, Con "Type")) [1 .. n]) (map (\ i -> ("C" ++ show i,  PCon "D" (map (\j -> Con ("p" ++ show j) ) [1 .. n]))) [1 .. n]) (Con "Type")]
     , \n -> let -- 19  Description: A single datatype where 'n' represents the number of indices, all needed for 'n' constructors
         genType 1 = Con "Nat"
         genType m = Arr (genType (m-1)) (Con "Nat")
@@ -231,18 +231,18 @@ _tests =
         
         genIndex 1 = [genIndexName 1]
         genIndex m = genIndexName m : genIndex (m-1)
-       in Module "IndicesParameters_Datatypes" [DefPDataType "D" (map (\i -> ("p" ++ show i)) [1 .. n]) [("C", Arr (Index (genIndex n) (Con "Nat")) (PCon "D" (map (\i -> Con ("p" ++ show i))  [1 .. n])))] (Arr (genType n) (Con "Type"))]
+       in Module "IndicesParameters_Datatypes" [DefPDataType "D" (map (\i -> ("p" ++ show i, Con "Type")) [1 .. n]) [("C", Arr (Index (genIndex n) (Con "Nat")) (PCon "D" (map (\i -> Con ("p" ++ show i))  [1 .. n])))] (Arr (genType n) (Con "Type"))]
     ,  \n -> --21 Description: A function pattern matching on 'n' constructors of a datatype
     --Name [(Name,Type)] Type Name [([Arg], Expr)]
     let 
-        genCall 1 = FunCall "F" [Var "c1"]
-        genCall p = Bin "+" (FunCall "F" [Var ("c" ++ show p)]) (genCall (p-1))
+        genCall 1 = FunCall "F" [Constructor "C1"]
+        genCall p = Bin "+" (FunCall "F" [Constructor ("C" ++ show p)]) (genCall (p-1))
     in
        Module "Pattern_Matching_Datatypes"
-       [DefDataType "D" (map (\ i -> ("c" ++ show i, Con "D")) [1 .. n]) (Con "Type"), --create datatype
+       [DefDataType "D" (map (\ i -> ("C" ++ show i, Con "D")) [1 .. n]) (Con "Type"), --create datatype
         OpenName "D",
         DefVar "N" (Just $ Con "Nat")
-       (Let [DefPatt "F" [("c", Con "D")] (Con "Nat") "c" (map (\i -> ([Arg ("c" ++ show i) (Con "D")], String (show i))) [1..n])] (genCall n))--pattern matching function
+       (Let [DefPatt "F" [("C", Con "D")] (Con "Nat") "C" (map (\i -> ([Arg ("C" ++ show i) (Con "D")], String (show i))) [1..n])] (genCall n))--pattern matching function
        ]
      ]
     


### PR DESCRIPTION
Fix capitalization in Rocq for pattern matching, generalized datatype to allow for parameters of all types, not just "Type"