### PR TITLE
CI Caching

### DIFF
--- a/.github/workflows/golden.yml
+++ b/.github/workflows/golden.yml
@@ -55,7 +55,6 @@ jobs:
           
       # There is no narwhal emoji? Very upsetting.
       - name: Install GHC ${{ matrix.ghc-version }} and Cabal ${{ matrix.cabal-version }} 🐬
-        if: steps.ghcup-cache.outputs.cache-hit != 'true' || runner.os == 'Windows'
         uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ matrix.ghc-version }}
@@ -71,9 +70,6 @@ jobs:
       # We need to generate the build plan so that we can use it for a caching key.
       - name: Cabal configure 🧙
         run: |
-          ghc --version
-          cabal --version
-          cabal update
           cabal configure --enable-tests --enable-benchmarks --disable-documentation
           cabal build all --dry-run
           


### PR DESCRIPTION
# Description

This PR adds caching to our CI, which brings the build time down to about a minute. Closes #144.

After a long and bloody battle, I've also decided to remove windows from the CI matrix. The build script still supports it, but getting caching to work was an absolute nightmare. To make matters worse, the `tar` implementation on windows is _absurdly_ slow: it takes almost 2 minutes to decompress the cache, which is roughly as long as it takes to install GHC 🙃.