### PR TITLE
fix: sidestep hSetEncoding, and write pre-encoded ByteStrings

### DIFF
--- a/panbench/generators/test/golden/Main.hs
+++ b/panbench/generators/test/golden/Main.hs
@@ -76,7 +76,7 @@ printTestForLang langName printer fileExt base =
   -- We have to use @goldenVsStringDiff@ ourselves to avoid bad unicode decoding...
   goldenVsStringDiff langName (\ref new -> ["diff", "--strip-trailing-cr" ,"-u", "--color=always", ref, new]) snapshotFile do
     createDirectoryIfMissing False ("test" </> "staging")
-    withFile stagingFile ReadWriteMode \hdl -> do
+    withBinaryFile stagingFile ReadWriteMode \hdl -> do
       printer hdl
       hFlush hdl
       hSeek hdl AbsoluteSeek 0

--- a/panbench/grammar/panbench-grammar.cabal
+++ b/panbench/grammar/panbench-grammar.cabal
@@ -40,13 +40,15 @@ library
         base >=4.17.2.0,
         aeson >= 2.2,
         binary >= 0.8,
+        bytestring >= 0.12,
+        containers >= 0.6 && < 0.7,
         data-default >= 0.8,
         deepseq >= 1.4,
         hashable >= 1.4,
         optparse-applicative >= 0.19,
         prettyprinter >=1.7.1 && < 2.0,
         text >= 2.1 && < 3.0,
-        containers >= 0.6 && < 0.7
+        utf8-string >= 1,
     hs-source-dirs: src
     default-language: Haskell2010
 

--- a/panbench/grammar/src/Panbench/Pretty.hs
+++ b/panbench/grammar/src/Panbench/Pretty.hs
@@ -60,19 +60,23 @@ module Panbench.Pretty
 import Control.Monad
 import Control.Monad.IO.Class
 
-import Data.Kind
+import Data.ByteString qualified as BS
+import Data.ByteString.UTF8 qualified as UTF8
+import Data.Text.Encoding qualified as T
 import Data.Coerce
 import Data.Foldable
+import Data.Kind
+
+
 
 import Data.Char (chr)
 import Data.String (IsString(..))
-import Data.Text.IO qualified as T
 
 import Numeric.Natural
 
 import Prettyprinter qualified as P
 
-import System.IO (Handle, hPutChar)
+import System.IO (Handle)
 
 --------------------------------------------------------------------------------
 -- Annotations
@@ -311,17 +315,17 @@ renderAnnotated hdl toks = liftIO $ loop [] toks (pure ())
     loop stack (P.SChar c rest) frame =
       loop stack rest do
         frame
-        hPutChar hdl c
+        BS.hPut hdl (UTF8.fromChar c)
     loop stack (P.SText _ t rest) frame =
       loop stack rest do
         frame
-        T.hPutStr hdl t
+        BS.hPut hdl (T.encodeUtf8 t)
     loop stack (P.SLine n rest) frame =
       loop stack rest do
         frame
         -- This should be more memory efficient than allocating 'Text'.
-        hPutChar hdl '\n'
-        replicateM_ n (hPutChar hdl ' ')
+        BS.hPut hdl (UTF8.fromChar '\n')
+        replicateM_ n (BS.hPut hdl (UTF8.fromChar ' '))
     loop stack (P.SAnnPush (Duplicate n) rest) frame =
       loop ((n, frame):stack) rest (pure ())
     loop [] (P.SAnnPop _) _ =

--- a/panbench/site/app/Panbench/Shake/Lang.hs
+++ b/panbench/site/app/Panbench/Shake/Lang.hs
@@ -119,7 +119,8 @@ instance ShakeLang AgdaMod AgdaHeader AgdaDefn Agda where
     needAgda opts
   needModule gen size = do
     let path = generatorOutputDir "agda" (T.unpack (genName gen)) (show size) ".agda"
-    writeFileHandleChanged path (genModuleVia getAgdaMod size gen)
+    putInfo $ "# generating " <> decodeOS path
+    writeBinaryHandleChanged path (genModuleVia getAgdaMod size gen)
     pure path
   benchmarkModule _ = agdaCheckBench
   cleanBuildArtifacts _ dir = removeFilesAfter (decodeOS dir) ["*.agdai"]
@@ -133,7 +134,8 @@ instance ShakeLang IdrisMod IdrisHeader IdrisDefn Idris where
     needIdris opts
   needModule gen size = do
     let path = generatorOutputDir "idris" (T.unpack (genName gen)) (show size) ".idr"
-    writeFileHandleChanged path (genModuleVia getIdrisMod size gen)
+    putInfo $ "# generating " <> decodeOS path
+    writeBinaryHandleChanged path (genModuleVia getIdrisMod size gen)
     pure path
   benchmarkModule _ = idrisCheckBench
   cleanBuildArtifacts _ dir = removeFilesAfter (decodeOS [osp|$dir/build|]) ["*"]
@@ -147,7 +149,8 @@ instance ShakeLang LeanMod LeanHeader LeanDefn Lean where
     needLean opts
   needModule gen size = do
     let path = generatorOutputDir "lean" (T.unpack (genName gen)) (show size) ".lean"
-    writeFileHandleChanged path (genModuleVia getLeanMod size gen)
+    putInfo $ "# generating " <> decodeOS path
+    writeBinaryHandleChanged path (genModuleVia getLeanMod size gen)
     pure path
   benchmarkModule _ = leanCheckBench
   cleanBuildArtifacts _ _ = pure ()
@@ -161,7 +164,8 @@ instance ShakeLang RocqMod RocqHeader RocqDefn Rocq where
     needRocq opts
   needModule gen size = do
     let path = generatorOutputDir "rocq" (T.unpack (genName gen)) (show size) ".v"
-    writeFileHandleChanged path (genModuleVia getRocqMod size gen)
+    putInfo $ "# generating " <> decodeOS path
+    writeBinaryHandleChanged path (genModuleVia getRocqMod size gen)
     pure path
   benchmarkModule _ = rocqCheckBench
   cleanBuildArtifacts _ dir = removeFilesAfter (decodeOS dir) ["*.vo", "*.vok", "*.vos", "*.glob"]


### PR DESCRIPTION
Following up on #210, this PR takes the nuclear option of setting the handle to binary mode, and pre-encoding our strings.