### PR TITLE
chore: trim down the size of the lean store

### DIFF
--- a/panbench/site/app/Panbench/Shake/File.hs
+++ b/panbench/site/app/Panbench/Shake/File.hs
@@ -8,6 +8,7 @@ module Panbench.Shake.File
   , writeTextFileChanged
   , writeBinaryHandleChanged
   , findExecutableAmong
+  , removePathForcibly
     -- $shakeFileOracle
   , addFileCacheOracle
   , askFileCacheOracle
@@ -86,6 +87,10 @@ removeFile_ x =
             perms <- Dir.getPermissions x
             Dir.setPermissions x perms{Dir.readable = True, Dir.searchable = True, Dir.writable = True}
             Dir.removeFile x
+
+-- | Remove a directory and all of its contents.
+removePathForcibly :: (MonadIO m) => OsPath -> m ()
+removePathForcibly path = liftIO $ Dir.removePathForcibly path
 
 -- | Return the first executable found amongst a list of names.
 findExecutableAmong :: (MonadIO m) => [OsPath] -> m (Maybe OsPath)

--- a/panbench/site/app/Panbench/Shake/Lang/Lean.hs
+++ b/panbench/site/app/Panbench/Shake/Lang/Lean.hs
@@ -78,10 +78,13 @@ withLeanClone rev storeDir act =
 leanInstall :: LeanQ -> OsPath -> Action ()
 leanInstall LeanQ{..} storeDir = do
     withLeanClone leanInstallRev storeDir \workDir -> do
+      let stage = "stage2"
       withAllCores \nCores -> do
         command_ [Cwd (decodeOS workDir)] "cmake" leanCMakeFlags
-        command_ [Cwd (decodeOS workDir)] "make" (["stage2", "-C", "build/release", "-j" ++ show nCores] ++ leanMakeFlags)
-      copyDirectoryRecursive [osp|$workDir/build/release/stage3|] storeDir
+        command_ [Cwd (decodeOS workDir)] "make" ([stage, "-C", "build/release", "-j" ++ show nCores] ++ leanMakeFlags)
+      copyDirectoryRecursive [osp|$workDir/build/release/$stage|] storeDir
+    -- This shaves ~750 MB off the size of the store.
+    removePathForcibly [osp|$storeDir/lib/temp|]
 
 -- | Require that a particular version of @lean@ is installed,
 -- and return the absolute path pointing to the executable.


### PR DESCRIPTION
We don't need to keep around temp files, and these bloat the size of the cache by about 750 megs.