### PR TITLE
Fair sequential definitions

### DIFF
--- a/app/site/app/Main.hs
+++ b/app/site/app/Main.hs
@@ -101,7 +101,7 @@ allGenerators =
   , (Postulates.generator, Range (Log 2) 0 17)
   , (RecordParameters.generator, Range (Log 2) 0 11)
   , (RecordTelescope.generator, Range (Log 2) 0 8)
-  , (SequentialDefinitions.generator, Range (Log 2) 0 13)
+  , (SequentialDefinitions.generator, Range (Log 2) 0 17)
   , (SequentialDependentRecords.generator, Range (Log 2) 0 11)
   , (SequentialSimpleRecords.generator, Range (Log 2) 0 12)
   , (SimpleDataDefinitions.generator, Range (Log 2) 0 13)

--- a/lib/generators/src/Panbench/Generator/SequentialDefinitions.hs
+++ b/lib/generators/src/Panbench/Generator/SequentialDefinitions.hs
@@ -14,7 +14,7 @@ generator :: _ => GenModule hdr defn Natural
 generator = GenModule "SequentialDefinitions"
   [ import_ "Data.Nat"
   ] \size ->
-  [ [] |- nameN "x" i .: builtin "Nat" .= nat i
+  [ [] |- nameN "x" i .: builtin "Nat" .= nat 1
   | i <- [1..size]
   ] ++
   [ [] |- "result" .: builtin "Nat" .= op2 "+" (nameN "x" 1) (nameN "x" size)

--- a/lib/generators/test/snapshot/SequentialDefinitions.agda
+++ b/lib/generators/test/snapshot/SequentialDefinitions.agda
@@ -6,16 +6,16 @@ x₁ : Nat
 x₁ = 1
 
 x₂ : Nat
-x₂ = 2
+x₂ = 1
 
 x₃ : Nat
-x₃ = 3
+x₃ = 1
 
 x₄ : Nat
-x₄ = 4
+x₄ = 1
 
 x₅ : Nat
-x₅ = 5
+x₅ = 1
 
 result : Nat
 result = x₁ + x₅

--- a/lib/generators/test/snapshot/SequentialDefinitions.idr
+++ b/lib/generators/test/snapshot/SequentialDefinitions.idr
@@ -4,16 +4,16 @@ x1 : Nat
 x1 = 1
 
 x2 : Nat
-x2 = 2
+x2 = 1
 
 x3 : Nat
-x3 = 3
+x3 = 1
 
 x4 : Nat
-x4 = 4
+x4 = 1
 
 x5 : Nat
-x5 = 5
+x5 = 1
 
 result : Nat
 result = x1 + x5

--- a/lib/generators/test/snapshot/SequentialDefinitions.lean
+++ b/lib/generators/test/snapshot/SequentialDefinitions.lean
@@ -1,11 +1,11 @@
 def x₁ : Nat := 1
 
-def x₂ : Nat := 2
+def x₂ : Nat := 1
 
-def x₃ : Nat := 3
+def x₃ : Nat := 1
 
-def x₄ : Nat := 4
+def x₄ : Nat := 1
 
-def x₅ : Nat := 5
+def x₅ : Nat := 1
 
 def result : Nat := x₁ + x₅

--- a/lib/generators/test/snapshot/SequentialDefinitions.v
+++ b/lib/generators/test/snapshot/SequentialDefinitions.v
@@ -3,13 +3,13 @@ Module SequentialDefinitions.
 
 Definition x1 : nat := 1.
 
-Definition x2 : nat := 2.
+Definition x2 : nat := 1.
 
-Definition x3 : nat := 3.
+Definition x3 : nat := 1.
 
-Definition x4 : nat := 4.
+Definition x4 : nat := 1.
 
-Definition x5 : nat := 5.
+Definition x5 : nat := 1.
 
 Definition result : nat := x1 + x5.
 


### PR DESCRIPTION
Previously, we were using `let xi := i` for `SequentialLetDefinitions`. This means that we were testing both sequential definitions *and* arithmetic performance, which strongly biases towards systems that have built-in natural numbers. This PR replaces the let bindings with `let xi := 1`, which causes rocq to no longer explode at 2^13. As a result, I've bumped up the max bound to `2^17`. The results are linked below; lean dies early due to a stack overflow. This is almost certainly guaranteed to be due to some stack-unsafe linked list traversals. I've linked the report below.

[index.html](https://github.com/user-attachments/files/27284184/index.html)
