### PR TITLE
Nested xors

### DIFF
--- a/app/site/app/Main.hs
+++ b/app/site/app/Main.hs
@@ -65,6 +65,7 @@ import Panbench.Generator.LongName.RecordField qualified as LongNameRecordField
 import Panbench.Generator.ManyImplicits qualified as ManyImplicits
 import Panbench.Generator.NestedLet qualified as NestedLet
 import Panbench.Generator.NestedLetAdditions qualified as NestedLetAdditions
+import Panbench.Generator.NestedLetXors qualified as NestedLetXors
 import Panbench.Generator.NestedLetFunctions qualified as NestedLetFunctions
 import Panbench.Generator.Newlines qualified as Newlines
 import Panbench.Generator.Postulates qualified as Postulates
@@ -95,6 +96,7 @@ allGenerators =
   , (ManyImplicits.generator, Range (Log 2) 0 11)
   , (NestedLet.generator, Range (Log 2) 0 11)
   , (NestedLetAdditions.generator, Range (Log 2) 0 9)
+  , (NestedLetXors.generator, Range (Log 2) 0 9)
   , (NestedLetFunctions.generator, Range (Log 2) 0 9)
   , (Newlines.generator, Range (Log 10) 0 7)
   , (Parens.generator, Range (Log 2) 0 17)

--- a/lib/generators/panbench-generators.cabal
+++ b/lib/generators/panbench-generators.cabal
@@ -53,6 +53,7 @@ library
         Panbench.Generator.ManyImplicits
         Panbench.Generator.NestedLet
         Panbench.Generator.NestedLetAdditions
+        Panbench.Generator.NestedLetXors
         Panbench.Generator.NestedLetFunctions
         Panbench.Generator.Newlines
         Panbench.Generator.Parens

--- a/lib/generators/src/Panbench/Generator/NestedLetXors.hs
+++ b/lib/generators/src/Panbench/Generator/NestedLetXors.hs
@@ -1,0 +1,34 @@
+module Panbench.Generator.NestedLetXors where
+
+import Numeric.Natural
+
+import Panbench.Generator
+import Panbench
+
+generator
+  :: ( Import hdr "Data.Bool.Xor"
+     -- Definitions
+     , Definition defnLhs tm defns
+     , TelescopeLhs defnCell defnHd defnLhs
+     , Binder Single nm Single tm defnHd
+     -- Let Bindings
+     , Let letDefns tm, Name tm
+     , Definition letLhs tm letDefns
+     , TelescopeLhs letCell letHd letLhs
+     , Binder Single nm None tm letHd
+     -- Booleans
+     , Constant tm "Bool", Literal tm "Bool" Bool, Op2 tm "xor"
+     -- Names
+     , Name nm
+     )
+  => GenModule hdr defns Natural
+generator =
+    GenModule "NestedLetXor"
+      [ import_ "Data.Bool.Xor"
+      ] \size ->
+      [ ([] |- ("b" .: builtin "Bool")) .=
+          let_ ( ([] |- syn (nameN "x" 1) .= bool True)
+               : [[] |- syn (nameN "x" i) .= (op2 "xor" (nameN "x" (i - 1)) (nameN "x" (i - 1))) | i <- [2..size]]
+               ) $
+          nameN "x" size
+      ]

--- a/lib/generators/test/golden/Main.hs
+++ b/lib/generators/test/golden/Main.hs
@@ -47,6 +47,7 @@ import Panbench.Generator.ManyImplicits qualified as ManyImplicits
 
 import Panbench.Generator.NestedLet qualified as NestedLet
 import Panbench.Generator.NestedLetAdditions qualified as NestedLetAdditions
+import Panbench.Generator.NestedLetXors qualified as NestedLetXors
 import Panbench.Generator.NestedLetFunctions qualified as NestedLetFunctions
 
 import Panbench.Generator.Newlines qualified as Newlines
@@ -171,6 +172,7 @@ allGenerators =
   , ManyImplicits.generator
   , NestedLet.generator
   , NestedLetAdditions.generator
+  , NestedLetXors.generator
   , NestedLetFunctions.generator
   , Newlines.generator
   , Parens.generator

--- a/lib/generators/test/snapshot/NestedLetXor.agda
+++ b/lib/generators/test/snapshot/NestedLetXor.agda
@@ -1,0 +1,17 @@
+module NestedLetXor where
+
+open import Agda.Builtin.Bool
+
+xor : Bool → Bool → Bool
+xor true true = false
+xor false false = false
+xor _ _ = true
+
+b : Bool
+b =
+  let x₁ = true
+      x₂ = xor x₁ x₁
+      x₃ = xor x₂ x₂
+      x₄ = xor x₃ x₃
+      x₅ = xor x₄ x₄
+  in x₅

--- a/lib/generators/test/snapshot/NestedLetXor.idr
+++ b/lib/generators/test/snapshot/NestedLetXor.idr
@@ -1,0 +1,15 @@
+module Main
+
+import Data.Bool.Xor
+
+b : Bool
+b =
+  let x1 := True
+      x2 := xor x1 x1
+      x3 := xor x2 x2
+      x4 := xor x3 x3
+      x5 := xor x4 x4
+  in x5
+
+main : IO ()
+main = putStrLn ""

--- a/lib/generators/test/snapshot/NestedLetXor.lean
+++ b/lib/generators/test/snapshot/NestedLetXor.lean
@@ -1,0 +1,7 @@
+def b : Bool :=
+  let x₁ := Bool.true
+  let x₂ := x₁ ^^ x₁
+  let x₃ := x₂ ^^ x₂
+  let x₄ := x₃ ^^ x₃
+  let x₅ := x₄ ^^ x₄
+  x₅

--- a/lib/generators/test/snapshot/NestedLetXor.v
+++ b/lib/generators/test/snapshot/NestedLetXor.v
@@ -1,0 +1,12 @@
+
+Module NestedLetXor.
+
+Definition b : bool :=
+    let x1 := true
+    in let x2 := xorb x1 x1
+    in let x3 := xorb x2 x2
+    in let x4 := xorb x3 x3
+    in let x5 := xorb x4 x4
+    in x5.
+
+End NestedLetXor.

--- a/lib/grammar/src/Panbench/Grammar.hs
+++ b/lib/grammar/src/Panbench/Grammar.hs
@@ -75,6 +75,7 @@ module Panbench.Grammar
   , Literal(..)
   , lit
   , nat
+  , bool
   , sucN
   , list
   , string
@@ -516,6 +517,9 @@ lit sym x = mkLit @_ @sym x
 -- | Construct a @Nat@ literal.
 nat :: (Literal tm "Nat" Natural) => Natural -> tm
 nat = lit "Nat"
+
+bool :: (Literal tm "Bool" Bool) => Bool -> tm
+bool = lit "Bool"
 
 sucN :: (Op1 tm "suc", Parens tm) => Natural -> tm -> tm
 sucN 0 x = x

--- a/lib/grammar/src/Panbench/Grammar/Agda.hs
+++ b/lib/grammar/src/Panbench/Grammar/Agda.hs
@@ -332,6 +332,16 @@ instance Builtin AgdaTm "suc" (AgdaTm -> AgdaTm) where
 instance Builtin AgdaTm "+" (AgdaTm -> AgdaTm -> AgdaTm) where
   mkBuiltin x y = x <+> "+" <+> y
 
+instance Builtin AgdaTm "Bool" AgdaTm where
+  mkBuiltin = "Bool"
+
+instance Literal AgdaTm "Bool" Bool where
+  mkLit True = "true"
+  mkLit False = "false"
+
+instance Builtin AgdaTm "xor" (AgdaTm -> AgdaTm -> AgdaTm) where
+  mkBuiltin x y = "xor" <+> x <+> y
+
 instance Builtin AgdaTm "=" (AgdaTm -> AgdaTm -> AgdaTm) where
   mkBuiltin x y = x <+> "≡" <+> y
 
@@ -386,3 +396,15 @@ instance Import AgdaHeader "Data.List" where
 
 instance Import AgdaHeader "Data.String" where
   mkImport = openImport "Agda.Builtin.String"
+
+instance Import AgdaHeader "Data.Bool.Xor" where
+  mkImport =
+    openImport "Agda.Builtin.Bool" <>
+    [ hardlines
+      [ "xor : Bool → Bool → Bool"
+      , "xor true true = false"
+      , "xor false false = false"
+      , "xor _ _ = true"
+      , ""
+      ]
+    ]

--- a/lib/grammar/src/Panbench/Grammar/Idris.hs
+++ b/lib/grammar/src/Panbench/Grammar/Idris.hs
@@ -407,6 +407,16 @@ instance Builtin IdrisTm "suc" (IdrisTm -> IdrisTm) where
 instance Builtin IdrisTm "+" (IdrisTm -> IdrisTm -> IdrisTm) where
   mkBuiltin x y = x <+> "+" <+> y
 
+instance Builtin IdrisTm "Bool" IdrisTm where
+  mkBuiltin = "Bool"
+
+instance Literal IdrisTm "Bool" Bool where
+  mkLit True = "True"
+  mkLit False = "False"
+
+instance Builtin IdrisTm "xor" (IdrisTm -> IdrisTm -> IdrisTm) where
+  mkBuiltin x y = "xor" <+> x <+> y
+
 instance Builtin IdrisTm "=" (IdrisTm -> IdrisTm -> IdrisTm) where
   mkBuiltin x y = x <+> "=" <+> y
 
@@ -439,10 +449,13 @@ instance Module IdrisMod IdrisHeader IdrisDefns where
 -- Imports
 
 idrisImport :: Text -> IdrisHeader
-idrisImport nm = ["import" <+> pretty nm]
+idrisImport nm = ["import" <+> pretty nm <> hardline]
 
 instance Import IdrisHeader "Data.Nat" where
   mkImport = mempty
 
 instance Import IdrisHeader "Data.Id" where
   mkImport = mempty
+
+instance Import IdrisHeader "Data.Bool.Xor" where
+  mkImport = idrisImport "Data.Bool.Xor"

--- a/lib/grammar/src/Panbench/Grammar/Lean.hs
+++ b/lib/grammar/src/Panbench/Grammar/Lean.hs
@@ -290,6 +290,16 @@ instance Builtin LeanTm "suc" (LeanTm -> LeanTm) where
 instance Builtin LeanTm "+" (LeanTm -> LeanTm -> LeanTm) where
   mkBuiltin x y = x <+> "+" <+> y
 
+instance Builtin LeanTm "Bool" LeanTm where
+  mkBuiltin = "Bool"
+
+instance Literal LeanTm "Bool" Bool where
+  mkLit True = "Bool.true"
+  mkLit False = "Bool.false"
+
+instance Builtin LeanTm "xor" (LeanTm -> LeanTm -> LeanTm) where
+  mkBuiltin x y = x <+> "^^" <+> y
+
 instance Builtin LeanTm "=" (LeanTm -> LeanTm -> LeanTm) where
   mkBuiltin x y = x <+> "=" <+> y
 
@@ -340,4 +350,8 @@ instance Import LeanHeader "Data.Id" where
 
 -- | The equivalent of @Data.List@ is built-in for Lean.
 instance Import LeanHeader "Data.List" where
+  mkImport = mempty
+
+-- | The equivalent of @Data.List@ is built-in for Lean.
+instance Import LeanHeader "Data.Bool.Xor" where
   mkImport = mempty

--- a/lib/grammar/src/Panbench/Grammar/Rocq.hs
+++ b/lib/grammar/src/Panbench/Grammar/Rocq.hs
@@ -305,6 +305,16 @@ instance Builtin RocqTm "suc" (RocqTm -> RocqTm) where
 instance Builtin RocqTm "+" (RocqTm -> RocqTm -> RocqTm) where
   mkBuiltin x y = x <+> "+" <+> y
 
+instance Builtin RocqTm "Bool" RocqTm where
+  mkBuiltin = "bool"
+
+instance Literal RocqTm "Bool" Bool where
+  mkLit True = "true"
+  mkLit False = "false"
+
+instance Builtin RocqTm "xor" (RocqTm -> RocqTm -> RocqTm) where
+  mkBuiltin x y = "xorb" <+> x <+> y
+
 instance Builtin RocqTm "=" (RocqTm -> RocqTm -> RocqTm) where
   mkBuiltin x y = x <+> "=" <+> y
 
@@ -339,13 +349,17 @@ justImport :: Text -> RocqHeader
 justImport m = ["Import" <+> pretty m <> "."]
 
 -- | The equivalent of @Data.Nat@ is built-in for Rocq.
-instance Import (RocqHeader) "Data.Nat" where
+instance Import RocqHeader "Data.Nat" where
   mkImport = mempty
 
 -- | The equivalent of @Data.Nat@ is built-in for Rocq.
-instance Import (RocqHeader) "Data.Id" where
+instance Import RocqHeader "Data.Id" where
   mkImport = mempty
 
 -- | The equivalent of @Data.List@ is built-in for Rocq.
-instance Import (RocqHeader) "Data.List" where
+instance Import RocqHeader "Data.List" where
+  mkImport = mempty
+
+-- | The equivalent of @Data.Bool.Xor@ is built-in for Rocq.
+instance Import RocqHeader "Data.Bool.Xor" where
   mkImport = mempty


### PR DESCRIPTION
This PR adds an alternative to `NestedLetAdditions` that uses booleans instead of natural numbers to avoid biasing the results towards systems that have primops for addition. 

The results are essentially the same as `NestedLetAdditions` though. Only difference is that lean stays flat instead of steadily growing.

[index.html](https://github.com/user-attachments/files/27285544/index.html)
